### PR TITLE
GitHub api call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# File that contains the client_id, needed for OAuth
+# Gotta do this until we decide on how we can best store these secrets.
+/GitHub/secret.json 

--- a/GitHub/GitHubAPICall.py
+++ b/GitHub/GitHubAPICall.py
@@ -1,0 +1,33 @@
+import requests
+import json
+
+class GitHubAPICall:
+    # Base URLs
+    def __init__(self):
+        self.base_url_repos = "https://api.github.com/repos/"
+        self.base_url_users = "https://api.github.com/users/"
+
+    # Get the information of the owner, of the repository, and of the specific version.
+    def get_all_data(self, owner, repo, version):
+        repository_data = self.GetData(self.base_url_repos + owner + '/' + repo)
+        version_data = self.GetData(self.base_url_repos + owner + '/' + repo + '/releases/tags/' + version)
+        user_data = self.GetData(self.base_url_users + owner)
+        
+        return (repository_data, version_data, user_data)
+    
+    # Perform a simple GET request, based off the given URL
+    def get_data(self, api_url):
+        # Basic request to get the information.
+        data_response = requests.get(api_url,
+                                headers={'Authorization': 'token ' + json.load(open('secret.json'))['user_token'], # TEMPORARY USER TOKEN FOR TESTING
+                                'accept': 'application/vnd.github.v3+json'})
+
+        # See if we got a valid response
+        if data_response.status_code == 200:
+            data = data_response.json()
+        else:
+            print('Unable to get data from GitHub')
+            print('Error: ' + data_response.text)
+            data = None
+            
+        return data


### PR DESCRIPTION
Implemented a basic version of the API call. It uses a user_token to do the calls.

It returns 3 json datasets based off:

1. The owner's data
2. The repository's data
3. The release version's data

It uses a file called 'secret.json' which is contained in the '/GitHub/' folder for temporary user_token storage.
For this reason, I've edited the .gitignore as to not upload that file