### PR TITLE
run workflows on self-hosted runners

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -6,10 +6,8 @@ on:
       - development
 jobs:
   build:
-    strategy:
-      matrix:
-        python-version: [3.10.4]
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
+    container: python:3.10.4
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }}"
 


### PR DESCRIPTION
From now on, the workflows will be running on self-hosted runners.
Make sure to specify the correct container!