### PR TITLE
Added get_token routing

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,11 @@ from flask import Flask, make_response, request
 import json
 # Import the controller of the TrustSECO-Spider
 import controller
+# Import os and dotenv for loading environment variables
+import os
+from dotenv import load_dotenv
+# Import constants
+import constants
 # Import CORS needed
 from flask_cors import CORS
 
@@ -90,6 +95,31 @@ def set_tokens():
     # Return the output
     response = make_response(output)
     response.headers.set('Content-Type', 'text/plain')
+    return response
+
+# Return the tokens
+
+
+@app.get('/get_tokens')
+def get_tokens():
+    """Returns the tokens currently stored in the .env file"""
+
+    # (Re)load the .env file
+    load_dotenv(dotenv_path=constants.ENVIRON_FILE, override=True)
+
+    # Get the tokens
+    gh_token = os.getenv(constants.GITHUB_TOKEN)
+    lib_token = os.getenv(constants.LIBRARIES_TOKEN)
+
+    # Set the output
+    output_json = {
+        'github_token': gh_token,
+        'libraries_token': lib_token
+    }
+
+    # Return the output
+    response = make_response(output_json)
+    response.headers.set('Content-Type', 'application/json')
     return response
 
 


### PR DESCRIPTION
Simply send a GET request to /get_tokens to receive a JSON object containing the known tokens.